### PR TITLE
[CMake] Add minimal cmake file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 # Copyright 2016 Edward Diener
+# Copyright 2018 Mike Dev
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
 
@@ -27,6 +28,16 @@ matrix:
     - env: BOGUS_JOB=true
 
   include:
+    - os: linux
+      env: TEST_CMAKE=TRUE #Only for easier identification in travis web gui
+      install:
+        - git clone --depth 1 https://github.com/boostorg/preprocessor.git ../preprocessor
+
+      script:
+        - mkdir __build__ && cd __build__
+        - cmake ../test/test_cmake
+        - cmake --build .
+
     - os: linux
       env: TOOLSET=gcc COMPILER=g++ CXXSTD=c++11
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.5)
+project(BoostVmd LANGUAGES)
+
+add_library(boost_vmd INTERFACE)
+add_library(Boost::vmd ALIAS boost_vmd)
+
+target_include_directories(boost_vmd INTERFACE include)
+
+target_link_libraries(boost_vmd
+    INTERFACE
+        Boost::preprocessor
+)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,15 @@
 # Copyright 2017 Edward Diener
+# Copyright 2018 Mike Dev
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
 
 version: 1.0.{build}-{branch}
 
 shallow_clone: true
+
+configuration:
+  - unit_test
+  - test_cmake
 
 branches:
   only:
@@ -18,19 +23,40 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       TOOLSET: msvc-14.1
 
-install:
-  - cd ..
-  - git clone -b %APPVEYOR_REPO_BRANCH% https://github.com/boostorg/boost.git boost-root
-  - cd boost-root
-  - git submodule update --init tools/build
-  - git submodule update --init libs/config
-  - git submodule update --init tools/boostdep
-  - xcopy /s /e /q %APPVEYOR_BUILD_FOLDER% libs\vmd
-  - python tools/boostdep/depinst/depinst.py vmd
-  - bootstrap
-  - b2 headers
-
 build: off
 
-test_script:
-  - b2 libs/vmd/test toolset=%TOOLSET%
+for:
+-
+  matrix:
+    only:
+      - configuration: test_cmake
+
+  install:
+    - git clone --depth 1 https://github.com/boostorg/preprocessor.git ../preprocessor
+
+  test_script:
+    - mkdir __build__
+    - cd __build__
+    - cmake ../test/test_cmake
+    - cmake --build .
+
+-
+  matrix:
+    only:
+      - configuration: boost_test
+
+  install:
+    - cd ..
+    - git clone -b %APPVEYOR_REPO_BRANCH% https://github.com/boostorg/boost.git boost-root
+    - cd boost-root
+    - git submodule update --init tools/build
+    - git submodule update --init libs/config
+    - git submodule update --init tools/boostdep
+    - xcopy /s /e /q %APPVEYOR_BUILD_FOLDER% libs\vmd
+    - python tools/boostdep/depinst/depinst.py vmd
+    - bootstrap
+    - b2 headers
+
+
+  test_script:
+    - b2 libs/vmd/test toolset=%TOOLSET%

--- a/test/test_cmake/CMakeLists.txt
+++ b/test/test_cmake/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: This does NOT run the unit tests for Boost.Vmd.
+#       It only tests, if the CMakeLists.txt file in it's root works as expected
+
+cmake_minimum_required( VERSION 3.5 )
+
+project( BoostVmdCMakeSelfTest )
+
+add_subdirectory( ../../../preprocessor ${CMAKE_CURRENT_BINARY_DIR}/libs/preprocessor )
+add_subdirectory( ../.. ${CMAKE_CURRENT_BINARY_DIR}/libs/boost_vmd )
+
+add_executable( boost_vmd_cmake_self_test main.cpp )
+target_link_libraries( boost_vmd_cmake_self_test Boost::vmd )
+

--- a/test/test_cmake/main.cpp
+++ b/test/test_cmake/main.cpp
@@ -1,0 +1,5 @@
+#include <boost/vmd/vmd.hpp>
+
+int main() {
+
+}


### PR DESCRIPTION
Generate cmake target that can
be used by other libraries to express their dependency on
this library and retrieve any configuration information
such as the include directory, transitive dependencies,
necessary compiler options or the required c++ standards level.