### PR TITLE
msvc compiler warning turned as error are restored to warning

### DIFF
--- a/include/boost/vmd/detail/is_empty.hpp
+++ b/include/boost/vmd/detail/is_empty.hpp
@@ -11,8 +11,6 @@
 
 #if BOOST_VMD_MSVC
 
-# pragma warning(once:4002)
-
 #define BOOST_VMD_DETAIL_IS_EMPTY_IIF_0(t, b) b
 #define BOOST_VMD_DETAIL_IS_EMPTY_IIF_1(t, b) t
 


### PR DESCRIPTION
Fix [#563](https://github.com/boostorg/boost/issues/563)

Avoid changing warning state with msvc